### PR TITLE
Fix placeholder merge

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -5,6 +5,8 @@ from docx.oxml.table import CT_Tbl
 from docx.oxml.text.paragraph import CT_P
 from docx.table import Table
 from docx.text.paragraph import Paragraph
+from copy import deepcopy
+import re
 from docx.shared import Inches
 from PIL import Image
 
@@ -73,31 +75,34 @@ def merge_into_template(sections, template_path, out_path):
         return
     tpl = Document(template_path)
     body = tpl.element.body
-    # for each block (p or table) in template
+    # Regex zum Finden von Platzhaltern wie {SECTION_1}
+    pattern = re.compile(r"{SECTION_(\d+)}")
+
     for block in list(iter_block_items(tpl)):
         if not isinstance(block, Paragraph):
             continue
         text = block.text
-        for num, blocks in sections.items():
-            # Platzhalter im Template sind in der Form {SECTION_1}
-            placeholder = f'{{SECTION_{num}}}'
-            if placeholder in text:
-                idx = body.index(block._element)
-                body.remove(block._element)
-                # insert raw content
-                for b in blocks:
-                    elem = getattr(b, '_element', b)
-                    body.insert(idx, elem)
-                    idx += 1
-                # fallback icon
-                icon = os.path.join(ICONS_DIR, f'GHS{num}.png')
-                if os.path.isfile(icon):
-                    w_in, _ = get_image_size_inches(icon)
-                    pic_p = tpl.add_paragraph()
-                    run = pic_p.add_run()
-                    run.add_picture(icon, width=Inches(w_in))
-                    body.insert(idx, pic_p._p)
-                break
+        m = pattern.search(text)
+        if not m:
+            continue
+        num = m.group(1)
+        idx = body.index(block._element)
+        body.remove(block._element)
+
+        # entsprechenden Abschnitt einfügen, falls vorhanden
+        for b in sections.get(num, []):
+            elem = getattr(b, '_element', b)
+            body.insert(idx, deepcopy(elem))
+            idx += 1
+
+        # ggf. Fallback-Icon einfügen
+        icon = os.path.join(ICONS_DIR, f'GHS{num}.png')
+        if os.path.isfile(icon):
+            w_in, _ = get_image_size_inches(icon)
+            pic_p = tpl.add_paragraph()
+            run = pic_p.add_run()
+            run.add_picture(icon, width=Inches(w_in))
+            body.insert(idx, pic_p._p)
     tpl.save(out_path)
 
 


### PR DESCRIPTION
## Summary
- handle placeholders that don't have matching sections
- use regex and deepcopy when merging content

## Testing
- `python -m py_compile converter.py`
- `INPUT_DIR=sample_pdfs TEMPLATE_PATH=templates/master_template.docx OUTPUT_DIR=output ICONS_DIR=icons python converter.py`

------
https://chatgpt.com/codex/tasks/task_e_685294e2fde48333ace0ad8a3c20e778