### PR TITLE
Handle placeholders inside tables

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -5,6 +5,8 @@ from docx.oxml.table import CT_Tbl
 from docx.oxml.text.paragraph import CT_P
 from docx.table import Table
 from docx.text.paragraph import Paragraph
+from copy import deepcopy
+import re
 from docx.shared import Inches
 from PIL import Image
 
@@ -40,30 +42,56 @@ def pdf_to_raw_docx(pdf_path, raw_docx_path):
 
 
 def iter_block_items(parent):
-    # yield paragraphs and tables
+    # yield paragraphs and tables only
     for child in parent.element.body:
         if isinstance(child, CT_P):
             yield Paragraph(child, parent)
         elif isinstance(child, CT_Tbl):
             yield Table(child, parent)
-        else:
-            yield child
 
 
 def extract_sections(raw_docx_path):
     doc = Document(raw_docx_path)
-    sections = {}
+    sections: dict[str, list] = {}
     current = None
+    header_re = re.compile(r"^\s*abschnitt\s*(\d+)\s*[:.-]?", re.I)
+
+    ns = {'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+
     for block in iter_block_items(doc):
-        text = block.text.strip() if isinstance(block, Paragraph) else ''
-        if text.upper().startswith('ABSCHNITT'):
-            parts = text.split()
-            if len(parts) >= 2:
-                num = ''.join(ch for ch in parts[1] if ch.isdigit())
-                current = num
-                sections[num] = []
-        if current:
-            sections[current].append(block)
+        if isinstance(block, Paragraph):
+            text = block.text.strip()
+            m = header_re.match(text)
+            if m:
+                current = m.group(1)
+                sections[current] = []
+                continue  # skip heading itself
+            if current:
+                sections[current].append(block)
+        elif isinstance(block, Table):
+            found_idx = None
+            for i, row in enumerate(block.rows):
+                for cell in row.cells:
+                    for para in cell.paragraphs:
+                        m = header_re.match(para.text.strip())
+                        if m:
+                            current = m.group(1)
+                            sections[current] = []
+                            found_idx = i
+                            break
+                    if found_idx is not None:
+                        break
+                if found_idx is not None:
+                    break
+            if found_idx is not None:
+                tbl_elem = deepcopy(block._element)
+                rows = tbl_elem.findall('./w:tr', ns)
+                for r in rows[:found_idx+1]:
+                    tbl_elem.remove(r)
+                if tbl_elem.findall('./w:tr', ns):
+                    sections[current].append(tbl_elem)
+            elif current:
+                sections[current].append(block)
     return sections
 
 
@@ -73,31 +101,39 @@ def merge_into_template(sections, template_path, out_path):
         return
     tpl = Document(template_path)
     body = tpl.element.body
-    # for each block (p or table) in template
-    for block in list(iter_block_items(tpl)):
-        if not isinstance(block, Paragraph):
+    # Regex zum Finden von Platzhaltern wie {SECTION_1} oder {{SECTION_1}}
+    # (manche Templates nutzen doppelte geschweifte Klammern)
+    pattern = re.compile(r"\{{1,2}SECTION_(\d+)\}{1,2}")
+
+    ns = {'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+
+    # iterate over all paragraph elements, auch innerhalb von Tabellen
+    for p in tpl.element.xpath('.//w:p', namespaces=ns):
+        texts = [t.text or '' for t in p.xpath('.//w:t', namespaces=ns)]
+        text = ''.join(texts)
+        m = pattern.search(text)
+        if not m:
             continue
-        text = block.text
-        for num, blocks in sections.items():
-            # Platzhalter im Template sind in der Form {SECTION_1}
-            placeholder = f'{{SECTION_{num}}}'
-            if placeholder in text:
-                idx = body.index(block._element)
-                body.remove(block._element)
-                # insert raw content
-                for b in blocks:
-                    elem = getattr(b, '_element', b)
-                    body.insert(idx, elem)
-                    idx += 1
-                # fallback icon
-                icon = os.path.join(ICONS_DIR, f'GHS{num}.png')
-                if os.path.isfile(icon):
-                    w_in, _ = get_image_size_inches(icon)
-                    pic_p = tpl.add_paragraph()
-                    run = pic_p.add_run()
-                    run.add_picture(icon, width=Inches(w_in))
-                    body.insert(idx, pic_p._p)
-                break
+        num = m.group(1)
+        parent = p.getparent()
+        idx = parent.index(p)
+        parent.remove(p)
+
+        # entsprechenden Abschnitt einfuegen, falls vorhanden
+        for b in sections.get(num, []):
+            elem = getattr(b, '_element', b)
+            parent.insert(idx, deepcopy(elem))
+            idx += 1
+
+        # ggf. Fallback-Icon einfuegen
+        icon = os.path.join(ICONS_DIR, f'GHS{num}.png')
+        if os.path.isfile(icon):
+            w_in, _ = get_image_size_inches(icon)
+            pic_p = tpl.add_paragraph()
+            run = pic_p.add_run()
+            run.add_picture(icon, width=Inches(w_in))
+            body.remove(pic_p._p)
+            parent.insert(idx, pic_p._p)
     tpl.save(out_path)
 
 
@@ -112,8 +148,6 @@ if __name__ == '__main__':
         base, _ = os.path.splitext(f)
         raw = os.path.join(OUTPUT_DIR, f"{base}_raw.docx")
         final = os.path.join(OUTPUT_DIR, f"{base}.docx")
-        raw = os.path.join(OUTPUT_DIR, f.replace('.pdf', '_raw.docx'))
-        final = os.path.join(OUTPUT_DIR, f.replace('.pdf', '.docx'))
         print('Processing', f)
         pdf_to_raw_docx(pdf, raw)
         secs = extract_sections(raw)


### PR DESCRIPTION
## Summary
- ignore section headers in extracted content
- remove header rows when found inside tables
- detect and replace placeholders inside table cells

## Testing
- `python -m py_compile converter.py`
- `INPUT_DIR=sample_pdfs TEMPLATE_PATH=templates/master_template.docx OUTPUT_DIR=output ICONS_DIR=icons python converter.py`

------
https://chatgpt.com/codex/tasks/task_e_685294e2fde48333ace0ad8a3c20e778