### PR TITLE
Fix table handling when header row is the only row

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -97,6 +97,9 @@ def extract_sections(raw_docx_path: str) -> Dict[str, List]:
                     tbl_elem.tr_lst.pop(0)
                 if tbl_elem.tr_lst:
                     sections[current].append(Table(tbl_elem, doc))
+                else:
+                    # No rows left after removing the header -> keep original table
+                    sections[current].append(block)
             else:
                 if current:
                     sections[current].append(block)


### PR DESCRIPTION
## Summary
- keep header-only tables during section extraction

## Testing
- `python -m py_compile converter.py`
- `pip install -r requirements.txt`
- `python converter.py`

------
https://chatgpt.com/codex/tasks/task_e_6859aa8ac1508333a30d78de1515d541