### PR TITLE
Fix header deletion in table extraction

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -93,8 +93,8 @@ def extract_sections(raw_docx_path: str) -> Dict[str, List]:
                     current = header_sec
                     sections.setdefault(header_sec, [])
                 tbl_elem = deepcopy(block._element)
-                for _ in range(header_row + 1):
-                    tbl_elem.tr_lst.pop(0)
+                if 0 <= header_row < len(tbl_elem.tr_lst):
+                    tbl_elem.tr_lst.pop(header_row)
                 if tbl_elem.tr_lst:
                     sections[current].append(Table(tbl_elem, doc))
             else:


### PR DESCRIPTION
## Summary
- tweak `extract_sections` to only remove the header row from tables
- no functional tests are present in the repository

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859aa89ecac8333ae581bee98efaadc