### PR TITLE
Fix file name sanitization

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -149,8 +149,10 @@ if __name__ == '__main__':
         try:
             pdf_file = os.path.join(INPUT_DIR, f)
             base, _ = os.path.splitext(f)
-            raw = os.path.join(OUTPUT_DIR, f"{base}_raw.docx")
-            final = os.path.join(OUTPUT_DIR, f"{base}.docx")
+            # unerwünschte Zeichen aus dem Dateinamen entfernen
+            safe_base = safe_re.sub("_", base)
+            raw = os.path.join(OUTPUT_DIR, f"{safe_base}_raw.docx")
+            final = os.path.join(OUTPUT_DIR, f"{safe_base}.docx")
 
             print(f"Processing {f}...")
             pdf_to_raw_docx(pdf_file, raw)


### PR DESCRIPTION
## Summary
- ensure filenames for generated docs are sanitized

## Testing
- `python -m py_compile converter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa87781c8333ba9464f7b8c595ec